### PR TITLE
Refresh token stored in a cookie

### DIFF
--- a/buying_selling/config/urls.py
+++ b/buying_selling/config/urls.py
@@ -3,7 +3,6 @@ from django.urls import path, include
 from django.conf import settings
 from django.conf.urls.static import static
 from buying_selling.users import views as user_views
-from rest_framework_simplejwt.views import TokenRefreshView
 from django.views.generic import TemplateView
 
 catchall = TemplateView.as_view(template_name="index.html")
@@ -15,7 +14,7 @@ urlpatterns = [
     path("admin/doc/", include("django.contrib.admindocs.urls")),
     path("admin/", admin.site.urls),
     path("google/auth/token/", user_views.GoogleView.as_view(), name="google"),
-    path("google/auth/refresh/", TokenRefreshView.as_view(), name="token_refresh"),
+    path("google/auth/refresh/", user_views.RefreshTokenView.as_view(), name="token_refresh"),
     path("hi/", user_views.HelloView.as_view()),
 ]
 

--- a/buying_selling/users/views.py
+++ b/buying_selling/users/views.py
@@ -5,6 +5,9 @@ from rest_framework.views import APIView
 from rest_framework.response import Response
 from rest_framework_simplejwt.tokens import RefreshToken
 from rest_framework.permissions import IsAuthenticated
+from rest_framework import exceptions
+import jwt
+from django.conf import settings
 import requests
 from .models import MyUser
 
@@ -17,6 +20,9 @@ class HelloView(APIView):
         return Response({"message": "hi"})
 
 
+# - Use the following APIs while generating access token on Google OAuth playground -
+#       https://www.googleapis.com/auth/userinfo.email
+#       https://www.googleapis.com/auth/userinfo.profile
 class GoogleView(APIView):
     def post(self, request):
         payload = {"access_token": request.data.get("token")}  # validate the token
@@ -45,8 +51,42 @@ class GoogleView(APIView):
                 return Response({"error": "invalid email"})
 
         token = RefreshToken.for_user(user)
-        response = {}
+
+        response = Response()
         response["username"] = user.username
         response["access_token"] = str(token.access_token)
-        response["refresh_token"] = str(token)
-        return Response(response)
+
+        # set the refresh token as a http-only cookie
+        response.set_cookie(key='refreshtoken', value=str(token), httponly=True)
+
+        return response
+
+
+class RefreshTokenView(APIView):
+    """
+    Used to generate a new access token from the
+    refresh token stored in the http only cookie
+    """
+
+    def post(self, request):
+        refresh_token = request.COOKIES.get('refreshtoken')
+        if refresh_token is None:
+            raise exceptions.AuthenticationFailed('Authentication credentials were not provided.')
+        try:
+            payload = jwt.decode(refresh_token, settings.SIGNING_KEY, algorithms=['HS256'])
+        except jwt.ExpiredSignatureError:
+            raise exceptions.AuthenticationFailed('expired refresh token, please login again.')
+
+        user = MyUser.objects.get(id=payload.get('user_id'))
+        if user is None:
+            raise exceptions.AuthenticationFailed('User not found')
+
+        if not user.is_active:
+            raise exceptions.AuthenticationFailed('user is inactive')
+
+        token = RefreshToken.for_user(user)
+        response = Response()
+        response["username"] = user.username
+        response["access_token"] = str(token.access_token)
+
+        return response


### PR DESCRIPTION
This fixes #160 

## What was modified?
I've made changes to the original `GoogleView` to store the refresh token in a http-only cookie. Also coded a new view - `RefreshTokenView` to produce access tokens from the refresh token (now stored in a cookie).

## Why were these changes made?
Tokens stored in localstorage are prone to [XSS attacks](https://en.wikipedia.org/wiki/Cross-site_scripting) (i.e. Cross-site scripting). Thus, storing the `refresh token` within a http-only cookie, safeguards the application from a possible XSS attack.

### But...
Cookies are open to [CSRF attacks](https://en.wikipedia.org/wiki/Cross-site_request_forgery) and DRF automatically removes CSRF protection if you do not use `SessionAuthentication` AUTHENTICATION CLASS.
I might fix this issue in another PR.

## Testing 
- black - Passing
- flake8 - Passing
- Manually tested that refresh token is returned in a cookie from the SignIn/SignUp view (`GoogleView`)
- Tested that a access token is returned from the `RefreshTokenView`

### Note for the Client-side developers - 
- In the client-side, every request will contain refresh token in the cookies automatically.
- Send the access_token in the Authorization header.
- When he needs a new access_token, he need to send a POST request to refresh token endpoint.

